### PR TITLE
edit redirect to use current path

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -160,13 +160,12 @@ class TeachersController < ApplicationController
 
   def resend_welcome_email
     if @teacher.validated? || @is_admin
-      TeacherMailer.welcome_email(@teacher).deliver_now
       flash[:success] = "Welcome email resent successfully!"
+      TeacherMailer.welcome_email(@teacher).deliver_now
     else
-      flash[:alert] = "Error resending welcome email. \
-      Please ensure that your account has been validated by an administrator."
+      flash[:alert] = "Error resending welcome email. Please ensure that your account has been validated by an administrator."
     end
-    redirect_to edit_teacher_path(@teacher)
+    redirect_back(fallback_location: dashboard_path)
   end
 
   def import

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe TeachersController, type: :controller do
     it "succeeds when teacher is validated, sets success" do
       ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Validated"))
       validated_teacher = Teacher.find_by(first_name: "Validated")
+      request.env["HTTP_REFERER"] = edit_teacher_path(validated_teacher.id)
       post :resend_welcome_email, params: { id: validated_teacher.id }
       expect(flash[:success]).to eq("Welcome email resent successfully!")
       expect(response).to redirect_to(edit_teacher_path(validated_teacher.id))
@@ -196,10 +197,10 @@ RSpec.describe TeachersController, type: :controller do
     it "fails when teacher is not validated, sets alert" do
       ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Short"))
       nonvalidated_teacher = Teacher.find_by(first_name: "Short")
+      request.env["HTTP_REFERER"] = teacher_path(nonvalidated_teacher.id)
       post :resend_welcome_email, params: { id: nonvalidated_teacher.id }
-      expect(flash[:alert]).to eq("Error resending welcome email. \
-      Please ensure that your account has been validated by an administrator.")
-      expect(response).to redirect_to(edit_teacher_path(nonvalidated_teacher.id))
+      expect(flash[:alert]).to eq("Error resending welcome email. Please ensure that your account has been validated by an administrator.")
+      expect(response).to redirect_to(teacher_path(nonvalidated_teacher.id))
     end
   end
 end


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

<!-- Complete this section filling in the link to a tracker story. -->
https://www.pivotaltracker.com/n/projects/2406982/stories/187044317

## What this PR does:
This pull request fixes the resend_welcome_email redirect to use the original page of the user instead of a hardcoded path. The "Resend Welcome Email" button is in multiple locations of the app, so hardcoding a path would not work too well. 

### How should this PR be tested?
Already added RSpec testing, but manual testing can be done. 

* What do the specs/features test?
They test that the redirect_back works from multiple http links. They test for the two locations (that I know of) in the app that the button is present in and if redirect_back works. 

* Are there edge cases to watch out for?
Maybe if the user tries to run <http://root/teachers/:id/edit/resend_welcome_email(email_format)> directly into the searchbar, but even if someone does try that, the fallback will cover it.

### Checklist:

- [x] Has this been deployed to a staging environment or reviewed by a customer?
- [x] Tag someone for code review (either a coach / team member)
- [x] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay) (e.g. `michael/12345-add-new-feature` Any branch name will do as long as the story ID is there. You can use `git checkout -b [new-branch-name]`)
